### PR TITLE
Use process module util function for memory info.

### DIFF
--- a/circus/util.py
+++ b/circus/util.py
@@ -215,7 +215,7 @@ def get_info(process=None, interval=0, with_childs=False):
 
     info = {}
     try:
-        mem_info = process.get_memory_info()
+        mem_info = get_memory_info(process)
         info['mem_info1'] = mem_info[0]
         info['mem_info2'] = mem_info[1]
     except AccessDenied:


### PR DESCRIPTION
Resolves AttributeError exception in newer psutil versions.
